### PR TITLE
mat4::Transposed

### DIFF
--- a/template/tmpl8math.h
+++ b/template/tmpl8math.h
@@ -669,9 +669,10 @@ public:
 	CHECK_RESULT mat4 Transposed() const
 	{
 		mat4 M;
-		M[0] = cell[0], M[1] = cell[4], M[2] = cell[8];
-		M[4] = cell[1], M[5] = cell[5], M[6] = cell[9];
-		M[8] = cell[2], M[9] = cell[6], M[10] = cell[10];
+		M[0] = cell[0], M[1] = cell[4], M[2] = cell[8], M[3] = cell[12];
+		M[4] = cell[1], M[5] = cell[5], M[6] = cell[9], M[7] = cell[13];
+		M[8] = cell[2], M[9] = cell[6], M[10] = cell[10], M[11] = cell[14];
+		M[12] = cell[3], M[13] = cell[7], M[14] = cell[11], M[15] = cell[15];
 		return M;
 	}
 	CHECK_RESULT mat4 FastInvertedTransformNoScale() const


### PR DESCRIPTION
mat4::Transposed now transposes a 4x4 matrix instead of a 3x3 matrix. I believe this change shouldn't break anything as no code relies on the previous behavior.
